### PR TITLE
Add group management UI

### DIFF
--- a/Worldseed.Client.Blazor/DTOs/Group/ChangeMemberRankDto.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/ChangeMemberRankDto.cs
@@ -1,0 +1,9 @@
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public class ChangeMemberRankDto
+    {
+        public int GroupId { get; set; }
+        public int TargetUserId { get; set; }
+        public GroupRank NewRank { get; set; }
+    }
+}

--- a/Worldseed.Client.Blazor/DTOs/Group/CreateGroupRequestDto.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/CreateGroupRequestDto.cs
@@ -1,0 +1,7 @@
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public class CreateGroupRequestDto
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Worldseed.Client.Blazor/DTOs/Group/GroupRank.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/GroupRank.cs
@@ -1,0 +1,9 @@
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public enum GroupRank
+    {
+        Owner = 0,
+        Admin = 1,
+        Member = 2
+    }
+}

--- a/Worldseed.Client.Blazor/DTOs/Group/JoinGroupRequestDto.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/JoinGroupRequestDto.cs
@@ -1,0 +1,7 @@
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public class JoinGroupRequestDto
+    {
+        public int GroupId { get; set; }
+    }
+}

--- a/Worldseed.Client.Blazor/DTOs/Group/UpdateGroupNameDto.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/UpdateGroupNameDto.cs
@@ -1,0 +1,8 @@
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public class UpdateGroupNameDto
+    {
+        public int GroupId { get; set; }
+        public string NewName { get; set; }
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Group/ChangeMemberRank.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/ChangeMemberRank.razor
@@ -1,0 +1,29 @@
+@page "/group/changeRank"
+@using Worldseed.Client.Blazor.DTOs.Group
+@using Worldseed.Client.Blazor.DTOs
+@inject HttpClient httpClient
+@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@using System.Net.Http.Headers
+
+<h3>Change Member Rank</h3>
+<input type="number" @bind="dto.GroupId" placeholder="Group ID" />
+<input type="number" @bind="dto.TargetUserId" placeholder="Target User ID" />
+<select @bind="dto.NewRank">
+    <option value="0">Owner</option>
+    <option value="1">Admin</option>
+    <option value="2">Member</option>
+</select>
+<button @onclick="ChangeRank">Change</button>
+
+@code {
+    private ChangeMemberRankDto dto = new();
+
+    private async Task ChangeRank()
+    {
+        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/rank", dto);
+        dto = new ChangeMemberRankDto();
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
@@ -1,0 +1,23 @@
+@page "/group/create"
+@using Worldseed.Client.Blazor.DTOs.Group
+@using Worldseed.Client.Blazor.DTOs
+@inject HttpClient httpClient
+@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@using System.Net.Http.Headers
+
+<h3>Create Group</h3>
+<input @bind="group.Name" placeholder="Name" />
+<button @onclick="Create">Create</button>
+
+@code {
+    private CreateGroupRequestDto group = new();
+
+    private async Task Create()
+    {
+        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/createGroup", group);
+        group = new CreateGroupRequestDto();
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
@@ -1,0 +1,23 @@
+@page "/group/join"
+@using Worldseed.Client.Blazor.DTOs.Group
+@using Worldseed.Client.Blazor.DTOs
+@inject HttpClient httpClient
+@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@using System.Net.Http.Headers
+
+<h3>Join Group</h3>
+<input type="number" @bind="dto.GroupId" placeholder="Group ID" />
+<button @onclick="Join">Join</button>
+
+@code {
+    private JoinGroupRequestDto dto = new();
+
+    private async Task Join()
+    {
+        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/join", dto);
+        dto = new JoinGroupRequestDto();
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
@@ -1,0 +1,23 @@
+@page "/group/leave"
+@using Worldseed.Client.Blazor.DTOs.Group
+@using Worldseed.Client.Blazor.DTOs
+@inject HttpClient httpClient
+@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@using System.Net.Http.Headers
+
+<h3>Leave Group</h3>
+<input type="number" @bind="dto.GroupId" placeholder="Group ID" />
+<button @onclick="Leave">Leave</button>
+
+@code {
+    private JoinGroupRequestDto dto = new();
+
+    private async Task Leave()
+    {
+        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/leave", dto);
+        dto = new JoinGroupRequestDto();
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Group/UpdateGroupName.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/UpdateGroupName.razor
@@ -1,0 +1,24 @@
+@page "/group/updateName"
+@using Worldseed.Client.Blazor.DTOs.Group
+@using Worldseed.Client.Blazor.DTOs
+@inject HttpClient httpClient
+@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@using System.Net.Http.Headers
+
+<h3>Update Group Name</h3>
+<input type="number" @bind="dto.GroupId" placeholder="Group ID" />
+<input @bind="dto.NewName" placeholder="New Name" />
+<button @onclick="Update">Update</button>
+
+@code {
+    private UpdateGroupNameDto dto = new();
+
+    private async Task Update()
+    {
+        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/updateName", dto);
+        dto = new UpdateGroupNameDto();
+    }
+}

--- a/Worldseed.Client.Blazor/Shared/NavMenuAuthenticated.razor
+++ b/Worldseed.Client.Blazor/Shared/NavMenuAuthenticated.razor
@@ -36,6 +36,31 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/create">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Create Group
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/join">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Join Group
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/leave">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Leave Group
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/updateName">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Update Group Name
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/changeRank">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Change Member Rank
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="logout">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Logout
             </NavLink>


### PR DESCRIPTION
## Summary
- implement group management DTOs
- add pages for creating and managing groups
- extend authenticated nav menu with group links

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee1605b10832d87bb8c9166c646ad