### PR TITLE
Implement automatic JWT refresh in Blazor client

### DIFF
--- a/Worldseed.Client.Blazor/Pages/GetAccountUsers.razor
+++ b/Worldseed.Client.Blazor/Pages/GetAccountUsers.razor
@@ -1,7 +1,7 @@
 ﻿@using Worldseed.Client.Blazor.DTOs
 @using System.Net.Http.Headers
 @inject HttpClient httpClient
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @inject NavigationManager nav
 
 @page "/user/getAccountUsers"
@@ -42,9 +42,7 @@
 
         await base.OnInitializedAsync();
 
-        var currentToken = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-        new AuthenticationHeaderValue("Bearer", currentToken.Token);
+        await authService.SetAuthHeaderAsync();
 
         try
         {

--- a/Worldseed.Client.Blazor/Pages/Group/ChangeMemberRank.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/ChangeMemberRank.razor
@@ -2,7 +2,7 @@
 @using Worldseed.Client.Blazor.DTOs.Group
 @using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @using System.Net.Http.Headers
 
 <h3>Change Member Rank</h3>
@@ -20,9 +20,7 @@
 
     private async Task ChangeRank()
     {
-        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/rank", dto);
         dto = new ChangeMemberRankDto();
     }

--- a/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
@@ -2,7 +2,7 @@
 @using Worldseed.Client.Blazor.DTOs.Group
 @using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @using System.Net.Http.Headers
 
 <h3>Create Group</h3>
@@ -14,9 +14,7 @@
 
     private async Task Create()
     {
-        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/createGroup", group);
         group = new CreateGroupRequestDto();
     }

--- a/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
@@ -2,7 +2,7 @@
 @using Worldseed.Client.Blazor.DTOs.Group
 @using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @using System.Net.Http.Headers
 
 <h3>Join Group</h3>
@@ -14,9 +14,7 @@
 
     private async Task Join()
     {
-        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/join", dto);
         dto = new JoinGroupRequestDto();
     }

--- a/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
@@ -2,7 +2,7 @@
 @using Worldseed.Client.Blazor.DTOs.Group
 @using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @using System.Net.Http.Headers
 
 <h3>Leave Group</h3>
@@ -14,9 +14,7 @@
 
     private async Task Leave()
     {
-        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/leave", dto);
         dto = new JoinGroupRequestDto();
     }

--- a/Worldseed.Client.Blazor/Pages/Group/UpdateGroupName.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/UpdateGroupName.razor
@@ -2,7 +2,7 @@
 @using Worldseed.Client.Blazor.DTOs.Group
 @using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @using System.Net.Http.Headers
 
 <h3>Update Group Name</h3>
@@ -15,9 +15,7 @@
 
     private async Task Update()
     {
-        var token = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", token?.Token);
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/updateName", dto);
         dto = new UpdateGroupNameDto();
     }

--- a/Worldseed.Client.Blazor/Pages/UserCreate.razor
+++ b/Worldseed.Client.Blazor/Pages/UserCreate.razor
@@ -5,7 +5,7 @@
 @using System.Text.Json
 @using System.Net.Http.Headers
 @inject NavigationManager nav
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject AuthService authService
 @inject IBlazorStrap blazorStrap
 @using Worldseed.Client.Blazor.Helpers
 @inject HttpClient httpClient
@@ -66,9 +66,7 @@
     }
     private async Task SubmitCreateUser()
     {
-        var currentToken = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
-        httpClient.DefaultRequestHeaders.Authorization =
-    new AuthenticationHeaderValue("Bearer", currentToken.Token);
+        await authService.SetAuthHeaderAsync();
         using (var response = await httpClient.PostAsJsonAsync<CreateUserDTO>("https://api.worldseed.io/api/User/createUser", createUserDTO, System.Threading.CancellationToken.None))
         {
             if (response.IsSuccessStatusCode)

--- a/Worldseed.Client.Blazor/Program.cs
+++ b/Worldseed.Client.Blazor/Program.cs
@@ -12,6 +12,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 
 builder.Services.AddBlazorStrap();
 builder.Services.AddBlazoredLocalStorage();
+builder.Services.AddScoped<Worldseed.Client.Blazor.Services.AuthService>();
 
 
 await builder.Build().RunAsync();

--- a/Worldseed.Client.Blazor/Services/AuthService.cs
+++ b/Worldseed.Client.Blazor/Services/AuthService.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+using Worldseed.Client.Blazor.DTOs;
+
+namespace Worldseed.Client.Blazor.Services
+{
+    public class AuthService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILocalStorageService _localStorage;
+
+        public AuthService(HttpClient httpClient, ILocalStorageService localStorage)
+        {
+            _httpClient = httpClient;
+            _localStorage = localStorage;
+        }
+
+        public async Task<LoginTokenResponseDTO?> EnsureValidTokenAsync()
+        {
+            var tokenInfo = await _localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
+            if (tokenInfo == null)
+            {
+                return null;
+            }
+
+            if (tokenInfo.ValidTo <= DateTime.UtcNow.AddMinutes(1))
+            {
+                using var response = await _httpClient.PostAsJsonAsync(
+                    "https://api.worldseed.io/api/Auth/refresh-token",
+                    tokenInfo.RefreshTokenDTO);
+                if (response.IsSuccessStatusCode)
+                {
+                    var newToken = await response.Content.ReadFromJsonAsync<LoginTokenResponseDTO>();
+                    if (newToken != null)
+                    {
+                        await _localStorage.SetItemAsync("JWT", newToken);
+                        tokenInfo = newToken;
+                    }
+                }
+            }
+
+            return tokenInfo;
+        }
+
+        public async Task SetAuthHeaderAsync()
+        {
+            var token = await EnsureValidTokenAsync();
+            if (token != null && !string.IsNullOrEmpty(token.Token))
+            {
+                _httpClient.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", token.Token);
+            }
+        }
+    }
+}

--- a/Worldseed.Client.Blazor/_Imports.razor
+++ b/Worldseed.Client.Blazor/_Imports.razor
@@ -9,4 +9,5 @@
 @using Worldseed.Client.Blazor
 @using Worldseed.Client.Blazor.Shared
 @using BlazorStrap
+@using Worldseed.Client.Blazor.Services
 @using Worldseed.Client.Blazor.DTOs.Forum


### PR DESCRIPTION
## Summary
- add `AuthService` for checking JWT expiry and refreshing tokens via API
- register the new service in `Program.cs`
- expose the service globally via `_Imports.razor`
- use `AuthService` in pages that call authenticated endpoints

## Testing
- `dotnet build Worldseed.Client.Blazor.sln`

------
https://chatgpt.com/codex/tasks/task_e_684ee19e3194832dad100f73459e94eb