### PR TITLE
Add configurable API base URL

### DIFF
--- a/Worldseed.Client.Blazor/Pages/Forum/CreateForum.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/CreateForum.razor
@@ -5,7 +5,7 @@
     private CreateForumDTO forum = new();
     private async Task Create()
     {
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/forum/createForum", forum);
+        await httpClient.PostAsJsonAsync("api/forum/createForum", forum);
         forum = new CreateForumDTO();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Forum/ForumCategories.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/ForumCategories.razor
@@ -8,14 +8,14 @@
     private CreateForumCategoryDTO newCategory = new();
     protected override async Task OnInitializedAsync()
     {
-        categories = await httpClient.GetFromJsonAsync<List<ForumCategoryDTO>>($"https://api.worldseed.io/api/forum/{forumId}/categories") ?? new();
+        categories = await httpClient.GetFromJsonAsync<List<ForumCategoryDTO>>($"api/forum/{forumId}/categories") ?? new();
         newCategory.ForumId = forumId;
     }
     private async Task CreateCategory()
     {
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/forum/createCategory", newCategory);
+        await httpClient.PostAsJsonAsync("api/forum/createCategory", newCategory);
         newCategory = new CreateForumCategoryDTO { ForumId = forumId };
-        categories = await httpClient.GetFromJsonAsync<List<ForumCategoryDTO>>($"https://api.worldseed.io/api/forum/{forumId}/categories") ?? new();
+        categories = await httpClient.GetFromJsonAsync<List<ForumCategoryDTO>>($"api/forum/{forumId}/categories") ?? new();
     }
 }
 <h3>Forum Categories</h3>

--- a/Worldseed.Client.Blazor/Pages/Forum/ForumPosts.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/ForumPosts.razor
@@ -8,14 +8,14 @@
     private CreateForumPostDTO newPost = new();
     protected override async Task OnInitializedAsync()
     {
-        posts = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadPostDTO>>($"https://api.worldseed.io/api/forum/thread/{threadId}/posts") ?? new();
+        posts = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadPostDTO>>($"api/forum/thread/{threadId}/posts") ?? new();
         newPost.ForumCategoryThreadId = threadId;
     }
     private async Task CreatePost()
     {
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/forum/createPost", newPost);
+        await httpClient.PostAsJsonAsync("api/forum/createPost", newPost);
         newPost = new CreateForumPostDTO { ForumCategoryThreadId = threadId };
-        posts = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadPostDTO>>($"https://api.worldseed.io/api/forum/thread/{threadId}/posts") ?? new();
+        posts = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadPostDTO>>($"api/forum/thread/{threadId}/posts") ?? new();
     }
 }
 <h3>Posts</h3>

--- a/Worldseed.Client.Blazor/Pages/Forum/ForumThreads.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/ForumThreads.razor
@@ -8,14 +8,14 @@
     private CreateForumThreadDTO newThread = new();
     protected override async Task OnInitializedAsync()
     {
-        threads = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadDTO>>($"https://api.worldseed.io/api/forum/category/{categoryId}/threads") ?? new();
+        threads = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadDTO>>($"api/forum/category/{categoryId}/threads") ?? new();
         newThread.ForumCategoryId = categoryId;
     }
     private async Task CreateThread()
     {
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/forum/createThread", newThread);
+        await httpClient.PostAsJsonAsync("api/forum/createThread", newThread);
         newThread = new CreateForumThreadDTO { ForumCategoryId = categoryId };
-        threads = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadDTO>>($"https://api.worldseed.io/api/forum/category/{categoryId}/threads") ?? new();
+        threads = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadDTO>>($"api/forum/category/{categoryId}/threads") ?? new();
     }
 }
 <h3>Threads</h3>

--- a/Worldseed.Client.Blazor/Pages/GetAccountUsers.razor
+++ b/Worldseed.Client.Blazor/Pages/GetAccountUsers.razor
@@ -46,7 +46,7 @@
 
         try
         {
-            var response = await httpClient.GetFromJsonAsync<List<GetAccountUsersResponseDTO>>("https://api.worldseed.io/api/User/getAccountUsers");
+            var response = await httpClient.GetFromJsonAsync<List<GetAccountUsersResponseDTO>>("api/User/getAccountUsers");
 
             if (response != null && response.Count > 0)
             {

--- a/Worldseed.Client.Blazor/Pages/Group/ChangeMemberRank.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/ChangeMemberRank.razor
@@ -21,7 +21,7 @@
     private async Task ChangeRank()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/rank", dto);
+        await httpClient.PostAsJsonAsync("api/group/rank", dto);
         dto = new ChangeMemberRankDto();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
@@ -15,7 +15,7 @@
     private async Task Create()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/createGroup", group);
+        await httpClient.PostAsJsonAsync("api/group/createGroup", group);
         group = new CreateGroupRequestDto();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
@@ -15,7 +15,7 @@
     private async Task Join()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/join", dto);
+        await httpClient.PostAsJsonAsync("api/group/join", dto);
         dto = new JoinGroupRequestDto();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
@@ -15,7 +15,7 @@
     private async Task Leave()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/leave", dto);
+        await httpClient.PostAsJsonAsync("api/group/leave", dto);
         dto = new JoinGroupRequestDto();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Group/UpdateGroupName.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/UpdateGroupName.razor
@@ -16,7 +16,7 @@
     private async Task Update()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("https://api.worldseed.io/api/group/updateName", dto);
+        await httpClient.PostAsJsonAsync("api/group/updateName", dto);
         dto = new UpdateGroupNameDto();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Login.razor
+++ b/Worldseed.Client.Blazor/Pages/Login.razor
@@ -58,7 +58,7 @@
 
     private async Task SubmitLogin()
     {
-        using (var response = await httpClient.PostAsJsonAsync<AccountLoginRequestDTO>("https://api.worldseed.io/api/Auth/login", accountLoginRequestDTO, System.Threading.CancellationToken.None))
+        using (var response = await httpClient.PostAsJsonAsync<AccountLoginRequestDTO>("api/Auth/login", accountLoginRequestDTO, System.Threading.CancellationToken.None))
         {
             if (response.IsSuccessStatusCode)
             {

--- a/Worldseed.Client.Blazor/Pages/Register.razor
+++ b/Worldseed.Client.Blazor/Pages/Register.razor
@@ -73,7 +73,7 @@
     }
     private async Task SubmitRegister()
     {
-        using (var response = await httpClient.PostAsJsonAsync<AccountRegisterRequestDTO>("https://api.worldseed.io/api/Auth/register", accountRegisterRequestDTO, System.Threading.CancellationToken.None))
+        using (var response = await httpClient.PostAsJsonAsync<AccountRegisterRequestDTO>("api/Auth/register", accountRegisterRequestDTO, System.Threading.CancellationToken.None))
         {
             if (response.IsSuccessStatusCode)
             {

--- a/Worldseed.Client.Blazor/Pages/UserCreate.razor
+++ b/Worldseed.Client.Blazor/Pages/UserCreate.razor
@@ -67,7 +67,7 @@
     private async Task SubmitCreateUser()
     {
         await authService.SetAuthHeaderAsync();
-        using (var response = await httpClient.PostAsJsonAsync<CreateUserDTO>("https://api.worldseed.io/api/User/createUser", createUserDTO, System.Threading.CancellationToken.None))
+        using (var response = await httpClient.PostAsJsonAsync<CreateUserDTO>("api/User/createUser", createUserDTO, System.Threading.CancellationToken.None))
         {
             if (response.IsSuccessStatusCode)
             {

--- a/Worldseed.Client.Blazor/Program.cs
+++ b/Worldseed.Client.Blazor/Program.cs
@@ -8,7 +8,8 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+var apiUrl = builder.Configuration["ApiBaseUrl"] ?? builder.HostEnvironment.BaseAddress;
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiUrl) });
 
 builder.Services.AddBlazorStrap();
 builder.Services.AddBlazoredLocalStorage();

--- a/Worldseed.Client.Blazor/Services/AuthService.cs
+++ b/Worldseed.Client.Blazor/Services/AuthService.cs
@@ -30,7 +30,7 @@ namespace Worldseed.Client.Blazor.Services
             if (tokenInfo.ValidTo <= DateTime.UtcNow.AddMinutes(1))
             {
                 using var response = await _httpClient.PostAsJsonAsync(
-                    "https://api.worldseed.io/api/Auth/refresh-token",
+                    "api/Auth/refresh-token",
                     tokenInfo.RefreshTokenDTO);
                 if (response.IsSuccessStatusCode)
                 {

--- a/Worldseed.Client.Blazor/wwwroot/appsettings.Development.json
+++ b/Worldseed.Client.Blazor/wwwroot/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "https://localhost:5001/"
+}

--- a/Worldseed.Client.Blazor/wwwroot/appsettings.json
+++ b/Worldseed.Client.Blazor/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseUrl": "https://api.worldseed.io/"
+}


### PR DESCRIPTION
## Summary
- use ApiBaseUrl from appsettings when creating HttpClient
- add environment-specific appsettings files
- update AuthService and pages to use relative API paths

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_684ee66bd658832d9b675b0212efc640