### PR TITLE
Improve group management UI

### DIFF
--- a/Worldseed.Client.Blazor/DTOs/Group/GroupDto.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/GroupDto.cs
@@ -1,0 +1,8 @@
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public class GroupDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Worldseed.Client.Blazor/DTOs/Group/GroupMemberDto.cs
+++ b/Worldseed.Client.Blazor/DTOs/Group/GroupMemberDto.cs
@@ -1,0 +1,11 @@
+using Worldseed.Client.Blazor.DTOs.Group;
+
+namespace Worldseed.Client.Blazor.DTOs.Group
+{
+    public class GroupMemberDto
+    {
+        public int UserId { get; set; }
+        public string UserName { get; set; }
+        public GroupRank Rank { get; set; }
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Forum/CreateForum.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/CreateForum.razor
@@ -1,15 +1,45 @@
 @page "/forum/create"
 @using Worldseed.Client.Blazor.DTOs.Forum
+@using Worldseed.Client.Blazor.DTOs.Group
 @inject HttpClient httpClient
+@inject AuthService authService
+
+<h3>Create Forum</h3>
+
+@if (groups.Count == 0)
+{
+    <p>You need to be in a group before creating a forum.</p>
+}
+else
+{
+    <input @bind="forum.Name" placeholder="Name" />
+    <select @bind="forum.GroupId">
+        @foreach (var g in groups)
+        {
+            <option value="@g.Id">@g.Name</option>
+        }
+    </select>
+    <button @onclick="Create">Create</button>
+}
+
 @code {
     private CreateForumDTO forum = new();
+    private List<GroupDto> groups = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await authService.SetAuthHeaderAsync();
+        groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/mine") ?? new();
+        if (groups.Count > 0)
+        {
+            forum.GroupId = groups[0].Id;
+        }
+    }
+
     private async Task Create()
     {
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("api/forum/createForum", forum);
         forum = new CreateForumDTO();
     }
 }
-<h3>Create Forum</h3>
-<input @bind="forum.Name" placeholder="Name" />
-<input type="number" @bind="forum.GroupId" placeholder="GroupId (optional)" />
-<button @onclick="Create">Create</button>

--- a/Worldseed.Client.Blazor/Pages/Group/GroupDetails.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/GroupDetails.razor
@@ -1,0 +1,60 @@
+@page "/group/{groupId:int}"
+@using Worldseed.Client.Blazor.DTOs.Group
+@inject HttpClient httpClient
+@inject AuthService authService
+
+<h3>@groupName</h3>
+
+@if (members.Count == 0)
+{
+    <p>No members found.</p>
+}
+else
+{
+    <ul>
+    @foreach (var m in members)
+    {
+        <li>
+            @m.UserName (@m.Rank)
+            <select @onchange="(e) => ChangeRank(m.UserId, int.Parse(e.Value.ToString()))">
+                <option value="0">Owner</option>
+                <option value="1">Admin</option>
+                <option value="2">Member</option>
+            </select>
+        </li>
+    }
+    </ul>
+}
+
+@code {
+    [Parameter]
+    public int groupId { get; set; }
+    private string groupName = string.Empty;
+    private List<GroupMemberDto> members = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        await authService.SetAuthHeaderAsync();
+        var groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/mine") ?? new();
+        groupName = groups.FirstOrDefault(g => g.Id == groupId)?.Name ?? $"Group {groupId}";
+        members = await httpClient.GetFromJsonAsync<List<GroupMemberDto>>($"api/group/{groupId}/members") ?? new();
+    }
+
+    private async Task ChangeRank(int userId, int newRank)
+    {
+        var dto = new ChangeMemberRankDto
+        {
+            GroupId = groupId,
+            TargetUserId = userId,
+            NewRank = (GroupRank)newRank
+        };
+        await authService.SetAuthHeaderAsync();
+        await httpClient.PostAsJsonAsync("api/group/rank", dto);
+        await LoadData();
+    }
+}

--- a/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/JoinGroup.razor
@@ -1,21 +1,37 @@
 @page "/group/join"
 @using Worldseed.Client.Blazor.DTOs.Group
-@using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
 @inject AuthService authService
-@using System.Net.Http.Headers
 
 <h3>Join Group</h3>
-<input type="number" @bind="dto.GroupId" placeholder="Group ID" />
-<button @onclick="Join">Join</button>
+
+@if (groups.Count == 0)
+{
+    <p>No groups available to join.</p>
+}
+else
+{
+    <ul>
+        @foreach (var g in groups)
+        {
+            <li>@g.Name <button @onclick="() => Join(g.Id)">Join</button></li>
+        }
+    </ul>
+}
 
 @code {
-    private JoinGroupRequestDto dto = new();
+    private List<GroupDto> groups = new();
 
-    private async Task Join()
+    protected override async Task OnInitializedAsync()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("api/group/join", dto);
-        dto = new JoinGroupRequestDto();
+        groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/joinable") ?? new();
+    }
+
+    private async Task Join(int groupId)
+    {
+        await authService.SetAuthHeaderAsync();
+        await httpClient.PostAsJsonAsync("api/group/join", new JoinGroupRequestDto { GroupId = groupId });
+        groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/joinable") ?? new();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/LeaveGroup.razor
@@ -1,21 +1,42 @@
 @page "/group/leave"
 @using Worldseed.Client.Blazor.DTOs.Group
-@using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
 @inject AuthService authService
-@using System.Net.Http.Headers
 
 <h3>Leave Group</h3>
-<input type="number" @bind="dto.GroupId" placeholder="Group ID" />
-<button @onclick="Leave">Leave</button>
+
+@if (groups.Count == 0)
+{
+    <p>You are not in any groups.</p>
+}
+else
+{
+    <ul>
+        @foreach (var g in groups)
+        {
+            <li>@g.Name <button @onclick="() => Leave(g.Id)">Leave</button></li>
+        }
+    </ul>
+}
 
 @code {
-    private JoinGroupRequestDto dto = new();
+    private List<GroupDto> groups = new();
 
-    private async Task Leave()
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadGroups();
+    }
+
+    private async Task LoadGroups()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("api/group/leave", dto);
-        dto = new JoinGroupRequestDto();
+        groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/mine") ?? new();
+    }
+
+    private async Task Leave(int groupId)
+    {
+        await authService.SetAuthHeaderAsync();
+        await httpClient.PostAsJsonAsync("api/group/leave", new JoinGroupRequestDto { GroupId = groupId });
+        await LoadGroups();
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Group/MyGroups.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/MyGroups.razor
@@ -1,0 +1,30 @@
+@page "/group/my"
+@using Worldseed.Client.Blazor.DTOs.Group
+@inject HttpClient httpClient
+@inject AuthService authService
+
+<h3>My Groups</h3>
+
+@if (groups.Count == 0)
+{
+    <p>You are not part of any group.</p>
+}
+else
+{
+    <ul>
+    @foreach (var g in groups)
+    {
+        <li><a href="/group/@g.Id">@g.Name</a></li>
+    }
+    </ul>
+}
+
+@code {
+    private List<GroupDto> groups = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await authService.SetAuthHeaderAsync();
+        groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/mine") ?? new();
+    }
+}

--- a/Worldseed.Client.Blazor/Shared/NavMenuAuthenticated.razor
+++ b/Worldseed.Client.Blazor/Shared/NavMenuAuthenticated.razor
@@ -41,6 +41,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/my">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> My Groups
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="group/join">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Join Group
             </NavLink>
@@ -53,11 +58,6 @@
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="group/updateName">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Update Group Name
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="group/changeRank">
-                <span class="oi oi-list-rich" aria-hidden="true"></span> Change Member Rank
             </NavLink>
         </div>
         <div class="nav-item px-3">

--- a/Worldseed.Client.Blazor/_Imports.razor
+++ b/Worldseed.Client.Blazor/_Imports.razor
@@ -11,3 +11,4 @@
 @using BlazorStrap
 @using Worldseed.Client.Blazor.Services
 @using Worldseed.Client.Blazor.DTOs.Forum
+@using Worldseed.Client.Blazor.DTOs.Group


### PR DESCRIPTION
## Summary
- enable selecting groups when creating forums
- list joinable groups with buttons to join
- list groups you belong to with buttons to leave
- add pages to view group members and change ranks
- show user's groups in navigation menu
- add DTO types for groups

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3d50f14832d89f4d0d6f1fb28f5