### PR TITLE
Fix token refresh and group creation feedback

### DIFF
--- a/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/CreateGroup.razor
@@ -1,21 +1,52 @@
 @page "/group/create"
 @using Worldseed.Client.Blazor.DTOs.Group
-@using Worldseed.Client.Blazor.DTOs
 @inject HttpClient httpClient
 @inject AuthService authService
-@using System.Net.Http.Headers
+@inject NavigationManager nav
+@inject IBlazorStrap blazorStrap
 
 <h3>Create Group</h3>
-<input @bind="group.Name" placeholder="Name" />
-<button @onclick="Create">Create</button>
+<BSForm Model="group" OnValidSubmit="Create">
+    <BSInput InputType="InputType.Text" placeholder="Name" @bind-Value="group.Name" MarginBottom="Margins.Medium" />
+    <p><BSButton IsSubmit="true" Color="BSColor.Primary">Create</BSButton></p>
+</BSForm>
+
+<BSModal IsCentered="true" DataId="modalCreateFailed">
+    <Header>Error</Header>
+    <Content>Group creation failed :(</Content>
+    <Footer Context="modal">
+        <BSButton MarginStart="Margins.Auto" Color="BSColor.Secondary" @onclick="modal.HideAsync">Close</BSButton>
+    </Footer>
+</BSModal>
+
+<BSModal IsCentered="true" DataId="modalCreateSucceeded">
+    <Header>Success</Header>
+    <Content>Group created!</Content>
+    <Footer Context="modal">
+        <BSButton MarginStart="Margins.Auto" Color="BSColor.Secondary" @onclick="RedirectToMyGroups">Go to My Groups</BSButton>
+    </Footer>
+</BSModal>
 
 @code {
     private CreateGroupRequestDto group = new();
 
+    private async Task RedirectToMyGroups()
+    {
+        nav.NavigateTo("/group/my");
+    }
+
     private async Task Create()
     {
         await authService.SetAuthHeaderAsync();
-        await httpClient.PostAsJsonAsync("api/group/createGroup", group);
-        group = new CreateGroupRequestDto();
+        using var response = await httpClient.PostAsJsonAsync("api/group/createGroup", group);
+        if (response.IsSuccessStatusCode)
+        {
+            group = new CreateGroupRequestDto();
+            blazorStrap.ForwardClick("modalCreateSucceeded");
+        }
+        else
+        {
+            blazorStrap.ForwardClick("modalCreateFailed");
+        }
     }
 }

--- a/Worldseed.Client.Blazor/Services/AuthService.cs
+++ b/Worldseed.Client.Blazor/Services/AuthService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Net;
 using System.Threading.Tasks;
 using Blazored.LocalStorage;
 using Worldseed.Client.Blazor.DTOs;
@@ -29,9 +30,13 @@ namespace Worldseed.Client.Blazor.Services
 
             if (tokenInfo.ValidTo <= DateTime.UtcNow.AddMinutes(1))
             {
+                _httpClient.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue("Bearer", tokenInfo.Token);
+
                 using var response = await _httpClient.PostAsJsonAsync(
                     "api/Auth/refresh-token",
                     tokenInfo.RefreshTokenDTO);
+
                 if (response.IsSuccessStatusCode)
                 {
                     var newToken = await response.Content.ReadFromJsonAsync<LoginTokenResponseDTO>();
@@ -40,6 +45,11 @@ namespace Worldseed.Client.Blazor.Services
                         await _localStorage.SetItemAsync("JWT", newToken);
                         tokenInfo = newToken;
                     }
+                }
+                else if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    await _localStorage.RemoveItemAsync("JWT");
+                    return null;
                 }
             }
 


### PR DESCRIPTION
## Summary
- refresh auth tokens using current header and clear invalid session when unauthorized
- show feedback when creating a group and redirect on success

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0c172e2c832dacc29f3b0295c171