### PR TITLE
Add groups overview page

### DIFF
--- a/Worldseed.Client.Blazor/Pages/Group/GroupOverview.razor
+++ b/Worldseed.Client.Blazor/Pages/Group/GroupOverview.razor
@@ -1,0 +1,52 @@
+@page "/group/overview"
+@using Worldseed.Client.Blazor.DTOs.Group
+@using Worldseed.Client.Blazor.DTOs.Forum
+@inject HttpClient httpClient
+@inject AuthService authService
+
+<h3>My Groups Overview</h3>
+
+@if (groups.Count == 0)
+{
+    <p>You are not part of any group.</p>
+}
+else
+{
+    @foreach (var g in groups)
+    {
+        <h4>@g.Name</h4>
+        <p><strong>Members</strong></p>
+        <ul>
+        @foreach (var m in groupMembers[g.Id])
+        {
+            <li>@m.UserName (@m.Rank)</li>
+        }
+        </ul>
+        <p><strong>Forums</strong></p>
+        <ul>
+        @foreach (var f in groupForums[g.Id])
+        {
+            <li><a href="/forum/@f.Id/categories">@f.Name</a></li>
+        }
+        </ul>
+    }
+}
+
+@code {
+    private List<GroupDto> groups = new();
+    private Dictionary<int, List<GroupMemberDto>> groupMembers = new();
+    private Dictionary<int, List<ForumDTO>> groupForums = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await authService.SetAuthHeaderAsync();
+        groups = await httpClient.GetFromJsonAsync<List<GroupDto>>("api/group/mine") ?? new();
+        foreach (var g in groups)
+        {
+            var members = await httpClient.GetFromJsonAsync<List<GroupMemberDto>>($"api/group/{g.Id}/members") ?? new();
+            groupMembers[g.Id] = members;
+            var forums = await httpClient.GetFromJsonAsync<List<ForumDTO>>($"api/forum/group/{g.Id}") ?? new();
+            groupForums[g.Id] = forums;
+        }
+    }
+}

--- a/Worldseed.Client.Blazor/Shared/NavMenuAuthenticated.razor
+++ b/Worldseed.Client.Blazor/Shared/NavMenuAuthenticated.razor
@@ -46,6 +46,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="group/overview">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Group Overview
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="group/join">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Join Group
             </NavLink>


### PR DESCRIPTION
## Summary
- add GroupOverview page that lists user's groups with members and forums
- link new page from NavMenuAuthenticated

## Testing
- `dotnet build Worldseed.Client.Blazor.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852aff1de20832d9b7c1e6a27bd780b