### PR TITLE
Ensure posts and threads use auth identity

### DIFF
--- a/Worldseed.Client.Blazor/DTOs/Forum/CreateForumPostDTO.cs
+++ b/Worldseed.Client.Blazor/DTOs/Forum/CreateForumPostDTO.cs
@@ -3,7 +3,6 @@ namespace Worldseed.Client.Blazor.DTOs.Forum
     public class CreateForumPostDTO
     {
         public int ForumCategoryThreadId { get; set; }
-        public int OwnerId { get; set; }
         public string Content { get; set; }
     }
 }

--- a/Worldseed.Client.Blazor/DTOs/Forum/CreateForumThreadDTO.cs
+++ b/Worldseed.Client.Blazor/DTOs/Forum/CreateForumThreadDTO.cs
@@ -3,7 +3,6 @@ namespace Worldseed.Client.Blazor.DTOs.Forum
     public class CreateForumThreadDTO
     {
         public int ForumCategoryId { get; set; }
-        public int OwnerId { get; set; }
         public string Title { get; set; }
     }
 }

--- a/Worldseed.Client.Blazor/Pages/Forum/ForumPosts.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/ForumPosts.razor
@@ -1,6 +1,7 @@
 @page "/forum/thread/{threadId:int}/posts"
 @using Worldseed.Client.Blazor.DTOs.Forum
 @inject HttpClient httpClient
+@inject AuthService authService
 @code {
     [Parameter]
     public int threadId { get; set; }
@@ -13,6 +14,7 @@
     }
     private async Task CreatePost()
     {
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("api/forum/createPost", newPost);
         newPost = new CreateForumPostDTO { ForumCategoryThreadId = threadId };
         posts = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadPostDTO>>($"api/forum/thread/{threadId}/posts") ?? new();
@@ -27,5 +29,4 @@
 </ul>
 <h4>Create Post</h4>
 <textarea @bind="newPost.Content" placeholder="Content"></textarea>
-<input type="number" @bind="newPost.OwnerId" placeholder="Owner ID" />
 <button @onclick="CreatePost">Create</button>

--- a/Worldseed.Client.Blazor/Pages/Forum/ForumThreads.razor
+++ b/Worldseed.Client.Blazor/Pages/Forum/ForumThreads.razor
@@ -1,6 +1,7 @@
 @page "/forum/category/{categoryId:int}/threads"
 @using Worldseed.Client.Blazor.DTOs.Forum
 @inject HttpClient httpClient
+@inject AuthService authService
 @code {
     [Parameter]
     public int categoryId { get; set; }
@@ -13,6 +14,7 @@
     }
     private async Task CreateThread()
     {
+        await authService.SetAuthHeaderAsync();
         await httpClient.PostAsJsonAsync("api/forum/createThread", newThread);
         newThread = new CreateForumThreadDTO { ForumCategoryId = categoryId };
         threads = await httpClient.GetFromJsonAsync<List<ForumCategoryThreadDTO>>($"api/forum/category/{categoryId}/threads") ?? new();
@@ -27,5 +29,4 @@
 </ul>
 <h4>Create Thread</h4>
 <input @bind="newThread.Title" placeholder="Title" />
-<input type="number" @bind="newThread.OwnerId" placeholder="Owner ID" />
 <button @onclick="CreateThread">Create</button>


### PR DESCRIPTION
## Summary
- derive post and thread creator from authenticated user
- clean up creation forms
- remove `OwnerId` from thread/post creation DTOs

## Testing
- `dotnet build Worldseed.Client.Blazor.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6852aff47708832da8f4cb00b7cdb304