### PR TITLE
Fix repeated initialization

### DIFF
--- a/Worldseed.Client.Blazor/Pages/GetAccountUsers.razor
+++ b/Worldseed.Client.Blazor/Pages/GetAccountUsers.razor
@@ -27,10 +27,6 @@
 
 @code {
 
-    protected override async Task OnParametersSetAsync()
-    {
-        await OnInitializedAsync();
-    }
 
     private async Task GoToUserProfile(string username)
     {

--- a/Worldseed.Client.Blazor/Shared/MainLayout.razor
+++ b/Worldseed.Client.Blazor/Shared/MainLayout.razor
@@ -36,7 +36,7 @@
     
     protected override async Task OnParametersSetAsync()
     {
-        await OnInitializedAsync();
+        currentToken = await localStorage.GetItemAsync<LoginTokenResponseDTO>("JWT");
     }
     private LoginTokenResponseDTO currentToken = null;
 }


### PR DESCRIPTION
## Summary
- avoid calling `OnInitializedAsync` from layout and pages

## Testing
- `dotnet build ../Worldseed.Client.Blazor.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_6852aff53d34832dac0e7a270c9a90fb